### PR TITLE
Extend the Cookie Field Length in the Form

### DIFF
--- a/main.py
+++ b/main.py
@@ -541,7 +541,7 @@ if Setting:
     Session = container1.text_input(label="Session:", value=Session, placeholder=i18n("Session Placeholder"),max_chars=50, help=i18n("Session Help"))
     st.session_state.Session = Session
     # print(st.session_state.Session)
-    Cookie = container1.text_area(label="Cookie:", value=Cookie, placeholder=i18n("Cookie Placeholder"), height=150, max_chars=1500, help=i18n("Cookie Help"))
+    Cookie = container1.text_area(label="Cookie:", value=Cookie, placeholder=i18n("Cookie Placeholder"), height=150, max_chars=2000, help=i18n("Cookie Help"))
     st.session_state.Cookie = Cookie
     # print(st.session_state.Cookie)
 


### PR DESCRIPTION
你好，该PR我将表单的Cookie字段长度进行了扩展。发现sono的Cookie长度已经超过1500个字符了，不够用，现在已经扩展到2000字符，希望能合并，谢谢。
Hello, in this PR, I have extended the length of the Cookie field in the form. I found that the length of sono's Cookie has exceeded 1500 characters, which is not sufficient. Now, it has been extended to 2000 characters. I hope it can be merged. Thank you.